### PR TITLE
Update from googlecodelabs

### DIFF
--- a/.github/ISSUE_TEMPLATE/advanced-android-issue-template-for-testing-codelab.md
+++ b/.github/ISSUE_TEMPLATE/advanced-android-issue-template-for-testing-codelab.md
@@ -1,0 +1,25 @@
+---
+name: Advanced Android Issue Template for Testing Codelab
+about: Report problems with Advanced Android in Kotlin Testing codelab
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the problem**
+A clear and concise description of what the problem is.
+
+**In which lesson and step of the codelab can this issue be found?**
+Lesson number + step number. (ex. 5.2, Step 7)
+
+**How to reproduce?**
+What are the exact steps to reproduce the problem?
+
+**Versions**
+1. What version of Android Studio are you using?
+
+**Additional information**
+Add any other context about the problem here.
+
+**codelab:** advanced-android-kotlin

--- a/.github/ISSUE_TEMPLATE/advanced-android-issue-template-for-testing-codelab.md
+++ b/.github/ISSUE_TEMPLATE/advanced-android-issue-template-for-testing-codelab.md
@@ -1,7 +1,7 @@
 ---
 name: Advanced Android Issue Template for Testing Codelab
 about: Report problems with Advanced Android in Kotlin Testing codelab
-title: ''
+title: "[Codelab Issue] Testing Codelab 5.#, Step # - Issue description"
 labels: ''
 assignees: ''
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,94 @@
+name: CI
+
+# push will execute any commits that are pushed to all branches
+on: 
+  push:
+    branches: 
+      - end_codelab_1
+        end_codelab_2
+        end_codelab_3
+
+jobs:
+
+  # 1 Build will compile APK, test APK and run tests, lint, etc.
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      TERM: dumb
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+          
+    - name: Build and check
+      run: ./gradlew assembleDebug assembleDebugAndroidTest app:lintDebug testDebug --scan
+
+    - name: Upload build reports
+      if: always()
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-reports
+        path: app/build/reports
+
+    - name: Copy test results
+      if: always()
+      run: |
+        mkdir -p junit
+        find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} junit/ \;
+        
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v1
+      with:
+        name: junit-results
+        path: junit
+      
+    - name: Upload app APK
+      uses: actions/upload-artifact@v1
+      with:
+        name: app-debug
+        path: app/build/outputs/apk/debug/app-debug.apk
+        
+    - name: Upload Android Test APK
+      uses: actions/upload-artifact@v1
+      with:
+        name: app-debug-androidTest
+        path: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+
+
+  # Upload APKs to FTL and run instrumented tests
+  firebase:
+    name: Run UI tests with Firebase Test Lab
+    needs: build
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Download app APK
+        uses: actions/download-artifact@v1
+        with:
+          name: app-debug
+
+      - name: Download Android test APK
+        uses: actions/download-artifact@v1
+        with:
+          name: app-debug-androidTest
+
+      - name: Login to Google Cloud
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '281.0.0'
+          service_account_key: ${{ secrets.FTL_KEY_BASE64 }}
+
+      - name: Set current project
+        run: gcloud config set project ${{ secrets.FIREBASE_PROJECT_ID }}
+
+      - name: Run Instrumentation Tests in Firebase Test Lab
+        run: gcloud firebase test android run --type instrumentation --app app-debug/app-debug.apk --test app-debug-androidTest/app-debug-androidTest.apk --device model=Pixel2,version=28,locale=pl,orientation=portrait

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,8 +5,13 @@ on:
   push:
     branches: 
       - end_codelab_1
-        end_codelab_2
-        end_codelab_3
+      - end_codelab_2
+      - end_codelab_3
+  pull_request:
+    branches: 
+      - end_codelab_1
+      - end_codelab_2
+      - end_codelab_3
 
 jobs:
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,9 @@ android {
     //    enabled = true
     //    enabledForTests = true
     //}
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
     buildFeatures {
         dataBinding true
     }

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.example.android.architecture.blueprints.todoapp
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlinVersion = '1.3.72'
-    ext.navigationVersion = "2.1.0-alpha06"
+    ext.kotlinVersion = '1.4.10'
+    ext.navigationVersion = "2.3.0"
     repositories {
         google()
         jcenter()
@@ -37,9 +37,9 @@ ext {
     // App dependencies
     androidXVersion = '1.0.0'
     androidXTestCoreVersion = '1.2.0'
-    androidXTestExtKotlinRunnerVersion = '1.1.1'
+    androidXTestExtKotlinRunnerVersion = '1.1.2'
     androidXTestRulesVersion = '1.2.0-beta01'
-    androidXAnnotations = '1.0.1'
+    androidXAnnotations = '1.1.0'
     androidXLegacySupport = '1.0.0'
     appCompatVersion = '1.2.0'
     archLifecycleVersion = '2.2.0'
@@ -47,14 +47,14 @@ ext {
     cardVersion = '1.0.0'
     coroutinesVersion = '1.3.7'
     dexMakerVersion = '2.12.1'
-    espressoVersion = '3.2.0-beta01'
+    espressoVersion = '3.3.0'
     fragmentVersion = '1.1.0-alpha07'
-    fragmentKtxVersion = '1.1.0-rc01'
+    fragmentKtxVersion = '1.3.0-alpha08'
     hamcrestVersion = '1.3'
-    junitVersion = '4.12'
-    materialVersion = '1.0.0'
+    junitVersion = '4.13'
+    materialVersion = '1.2.1'
     mockitoVersion = '2.8.9'
-    recyclerViewVersion = '1.0.0'
+    recyclerViewVersion = '1.1.0'
     robolectricVersion = '4.3.1'
     roomVersion = '2.2.5'
     rulesVersion = '1.0.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,3 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
1. android.enableUnitTestBinaryResources property deprecated
2. Cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6. Please specify proper '-jvm-target' option