### PR TITLE
Failed to apply plugin [id 'com.android.application']

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,16 @@ android {
     buildFeatures {
         dataBinding true
     }
+
+    //Compile Options Block
+    compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
+
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,16 +28,16 @@ android {
     buildFeatures {
         dataBinding true
     }
+    //Compile-Options Block
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 
-    //Compile Options Block
     compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
         }
 
-        kotlinOptions {
-            jvmTarget = "1.8"
-        }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableUnitTestBinaryResources=true
+android.enableUnitTestBinaryResources=false


### PR DESCRIPTION
Found the app was not compiling and was showing  **Failed to apply plugin [id 'com.android.application']**
 or **enableUnitTestBinaryResources' is deprecated** 

To resolve the error I changed enableUnitTestBinaryResources to false in the gradle.properties file

`android.enableUnitTestBinaryResources=true`

Then I updated the compile options to target Java 8